### PR TITLE
Adding Django>=1.2 to the install requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,10 @@ setup(
     packages = [
         'django_mobile',
     ],
-    install_requires = ['setuptools'],
+    install_requires = [
+        'setuptools',
+        'Django>=1.2',
+        ],
     tests_require = ['mock'],
     test_suite = 'django_mobile_tests.runtests.runtests',
 )


### PR DESCRIPTION
I tried to use django-mobile on a django 1.1 site, it doesn't work. So I've added Django 1.2 to the install_requires for django-mobile.
