### PR TITLE
Added support for COOKIE.

### DIFF
--- a/django_mobile/__init__.py
+++ b/django_mobile/__init__.py
@@ -12,6 +12,9 @@ def get_flavour(request=None, default=None):
     # get flavour from session if enabled
     if request and settings.FLAVOURS_SESSION_KEY:
         flavour = request.session.get(settings.FLAVOURS_SESSION_KEY, None)
+    if(not flavour):
+        if request and settings.FLAVOURS_COOKIE_KEY:
+            flavour = request.COOKIES.get(settings.FLAVOURS_COOKIE_KEY, None)
     # check if flavour is set on request
     if not flavour and hasattr(request, 'flavour'):
         flavour = request.flavour

--- a/django_mobile/conf.py
+++ b/django_mobile/conf.py
@@ -24,6 +24,7 @@ class defaults(object):
     FLAVOURS_TEMPLATE_PREFIX = u''
     FLAVOURS_GET_PARAMETER = u'flavour'
     FLAVOURS_SESSION_KEY = u'flavour'
+    FLAVOURS_COOKIE_KEY = u'flavour'
     FLAVOURS_TEMPLATE_LOADERS = []
     for loader in django_settings.TEMPLATE_LOADERS:
         if loader != 'django_mobile.loader.Loader':


### PR DESCRIPTION
like sessions, added support for setting cookies for flavour, as sessions get flushed on django auth user logout, and if you want to persist the non login flow on selected flavour there is no way, other then get requests.

Couple of things.

1) COOKIE needs to be set by the code, i didn't change in set_flavour ( if author suggests i think we should do that)
2) COOKIE will only be picked if flavor is None (We might have to look at precedence though in detail)

BTW very nice piece of code, hope this helps, and finds its way into main code. :)

Thanks.
