### PR TITLE
Removed 'setuptools' from setup.py's 'install_requires'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
         'django_mobile',
         'django_mobile.cache',
     ],
-    install_requires = ['setuptools'],
     tests_require = ['Django', 'mock'],
     test_suite = 'django_mobile_tests.runtests.runtests',
 )


### PR DESCRIPTION
Having 'setuptools' in 'install_requires' causes problems when using 'pip install -t' and the like.  Just lost a few hours to this.
