### PR TITLE
Shows tried paths when template does not exists

### DIFF
--- a/django_mobile/loader.py
+++ b/django_mobile/loader.py
@@ -19,6 +19,24 @@ class Loader(BaseLoader):
         self.template_source_loaders = tuple(loaders)
         super(BaseLoader, self).__init__(*args, **kwargs)
 
+    def get_template_sources(self, template_name, template_dirs=None):
+        template_name = self.prepare_template_name(template_name)
+        for loader in self.template_source_loaders:
+            if hasattr(loader, 'get_template_sources'):
+                try:
+                    for result in  loader.get_template_sources(
+                                        template_name,
+                                        template_dirs):
+                        yield result
+                except UnicodeDecodeError:
+                    # The template dir name was a bytestring that wasn't valid UTF-8.
+                    raise
+                except ValueError:
+                    # The joined path was located outside of this particular
+                    # template_dir (it might be inside another one, so this isn't
+                    # fatal).
+                    pass
+
     def prepare_template_name(self, template_name):
         template_name = u'%s/%s' % (get_flavour(), template_name)
         if settings.FLAVOURS_TEMPLATE_PREFIX:


### PR DESCRIPTION
Implemented based on Django's default filesystem Loader[.get_template_sources()](https://github.com/django/django/blob/master/django/template/loaders/filesystem.py#L14)
