### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -306,7 +306,7 @@ changed in your own ``settings.py``:
     Determines how the selected flavour is stored persistently. Available
     values: ``'session'`` and ``'cookie'``.
     
-    **Default:** ``'session'``
+    **Default:** ``'cookie'``
 
 Cache Settings
 --------------


### PR DESCRIPTION
According to https://github.com/gregmuellegger/django-mobile/blob/master/django_mobile/conf.py#L28 the default is 'cookie'.
