### PR TITLE
Add a new context processor to determine if a UA is mobile

### DIFF
--- a/django_mobile/context_processors.py
+++ b/django_mobile/context_processors.py
@@ -1,4 +1,5 @@
 from django_mobile import get_flavour
+from django_mobile.ua_detector import UADetector
 from django_mobile.conf import settings
 
 
@@ -11,4 +12,10 @@ def flavour(request):
 def is_mobile(request):
     return {
         'is_mobile': get_flavour() == settings.DEFAULT_MOBILE_FLAVOUR,
+    }
+
+
+def is_mobile_user_agent(request):
+    return {
+        'is_mobile_user_agent': UADetector(request).is_user_agent_mobile()
     }

--- a/django_mobile/middleware.py
+++ b/django_mobile/middleware.py
@@ -1,6 +1,6 @@
-import re
 from django_mobile import flavour_storage
 from django_mobile import set_flavour, _init_flavour
+from django_mobile.ua_detector import UADetector
 from django_mobile.conf import settings
 
 
@@ -19,62 +19,8 @@ class SetFlavourMiddleware(object):
 
 
 class MobileDetectionMiddleware(object):
-    user_agents_test_match = (
-        "w3c ", "acs-", "alav", "alca", "amoi", "audi",
-        "avan", "benq", "bird", "blac", "blaz", "brew",
-        "cell", "cldc", "cmd-", "dang", "doco", "eric",
-        "hipt", "inno", "ipaq", "java", "jigs", "kddi",
-        "keji", "leno", "lg-c", "lg-d", "lg-g", "lge-",
-        "maui", "maxo", "midp", "mits", "mmef", "mobi",
-        "mot-", "moto", "mwbp", "nec-", "newt", "noki",
-        "xda",  "palm", "pana", "pant", "phil", "play",
-        "port", "prox", "qwap", "sage", "sams", "sany",
-        "sch-", "sec-", "send", "seri", "sgh-", "shar",
-        "sie-", "siem", "smal", "smar", "sony", "sph-",
-        "symb", "t-mo", "teli", "tim-", "tosh", "tsm-",
-        "upg1", "upsi", "vk-v", "voda", "wap-", "wapa",
-        "wapi", "wapp", "wapr", "webc", "winw", "xda-",)
-    user_agents_test_search = u"(?:%s)" % u'|'.join((
-        'up.browser', 'up.link', 'mmp', 'symbian', 'smartphone', 'midp',
-        'wap', 'phone', 'windows ce', 'pda', 'mobile', 'mini', 'palm',
-        'netfront', 'opera mobi',
-    ))
-    user_agents_exception_search = u"(?:%s)" % u'|'.join((
-        'ipad',
-    ))
-    http_accept_regex = re.compile("application/vnd\.wap\.xhtml\+xml", re.IGNORECASE)
-
-    def __init__(self):
-        user_agents_test_match = r'^(?:%s)' % '|'.join(self.user_agents_test_match)
-        self.user_agents_test_match_regex = re.compile(user_agents_test_match, re.IGNORECASE)
-        self.user_agents_test_search_regex = re.compile(self.user_agents_test_search, re.IGNORECASE)
-        self.user_agents_exception_search_regex = re.compile(self.user_agents_exception_search, re.IGNORECASE)
-
     def process_request(self, request):
-        is_mobile = False
-
-        if request.META.has_key('HTTP_USER_AGENT'):
-            user_agent = request.META['HTTP_USER_AGENT']
-
-            # Test common mobile values.
-            if self.user_agents_test_search_regex.search(user_agent) and \
-                not self.user_agents_exception_search_regex.search(user_agent):
-                is_mobile = True
-            else:
-                # Nokia like test for WAP browsers.
-                # http://www.developershome.com/wap/xhtmlmp/xhtml_mp_tutorial.asp?page=mimeTypesFileExtension
-
-                if request.META.has_key('HTTP_ACCEPT'):
-                    http_accept = request.META['HTTP_ACCEPT']
-                    if self.http_accept_regex.search(http_accept):
-                        is_mobile = True
-
-            if not is_mobile:
-                # Now we test the user_agent from a big list.
-                if self.user_agents_test_match_regex.match(user_agent):
-                    is_mobile = True
-
-        if is_mobile:
+        if UADetector(request).is_user_agent_mobile():
             set_flavour(settings.DEFAULT_MOBILE_FLAVOUR, request)
         else:
             set_flavour(settings.FLAVOURS[0], request)

--- a/django_mobile/middleware.py
+++ b/django_mobile/middleware.py
@@ -19,8 +19,17 @@ class SetFlavourMiddleware(object):
 
 
 class MobileDetectionMiddleware(object):
+    """
+    This middleware detects and sets a flavour in case there is no previous
+    flavour saved. In that case the saved flavour is set.
+    """
     def process_request(self, request):
-        if UADetector(request).is_user_agent_mobile():
-            set_flavour(settings.DEFAULT_MOBILE_FLAVOUR, request)
+        saved_flavour = flavour_storage.get(request)
+
+        if saved_flavour is None:
+            if UADetector(request).is_user_agent_mobile():
+                    set_flavour(settings.DEFAULT_MOBILE_FLAVOUR, request)
+            else:
+                set_flavour(settings.FLAVOURS[0], request)
         else:
-            set_flavour(settings.FLAVOURS[0], request)
+            set_flavour(saved_flavour, request)

--- a/django_mobile/ua_detector.py
+++ b/django_mobile/ua_detector.py
@@ -1,0 +1,68 @@
+import re
+
+
+class UADetector(object):
+    """
+    class to detect if an User Agent is a mobile one
+    """
+    USER_AGENTS_TEST_MATCH = (
+        "w3c ", "acs-", "alav", "alca", "amoi", "audi",
+        "avan", "benq", "bird", "blac", "blaz", "brew",
+        "cell", "cldc", "cmd-", "dang", "doco", "eric",
+        "hipt", "inno", "ipaq", "java", "jigs", "kddi",
+        "keji", "leno", "lg-c", "lg-d", "lg-g", "lge-",
+        "maui", "maxo", "midp", "mits", "mmef", "mobi",
+        "mot-", "moto", "mwbp", "nec-", "newt", "noki",
+        "xda",  "palm", "pana", "pant", "phil", "play",
+        "port", "prox", "qwap", "sage", "sams", "sany",
+        "sch-", "sec-", "send", "seri", "sgh-", "shar",
+        "sie-", "siem", "smal", "smar", "sony", "sph-",
+        "symb", "t-mo", "teli", "tim-", "tosh", "tsm-",
+        "upg1", "upsi", "vk-v", "voda", "wap-", "wapa",
+        "wapi", "wapp", "wapr", "webc", "winw", "xda-",
+    )
+    USER_AGENTS_TEST_MATCH = r'^(?:%s)' % '|'.join(USER_AGENTS_TEST_MATCH)
+    USER_AGENTS_TEST_MATCH_REGEX = re.compile(USER_AGENTS_TEST_MATCH, re.IGNORECASE)
+
+    USER_AGENTS_TEST_SEARCH = u"(?:%s)" % u'|'.join((
+        'up.browser', 'up.link', 'mmp', 'symbian', 'smartphone', 'midp',
+        'wap', 'phone', 'windows ce', 'pda', 'mobile', 'mini', 'palm',
+        'netfront', 'opera mobi',
+    ))
+    USER_AGENTS_TEST_SEARCH_REGEX = re.compile(USER_AGENTS_TEST_SEARCH, re.IGNORECASE)
+
+    USER_AGENTS_EXCEPTION_SEARCH = u"(?:%s)" % u'|'.join((
+        'ipad',
+    ))
+    USER_AGENTS_EXCEPTION_SEARCH_REGEX = re.compile(USER_AGENTS_EXCEPTION_SEARCH, re.IGNORECASE)
+
+    HTTP_ACCEPT_REGEX = re.compile("application/vnd\.wap\.xhtml\+xml", re.IGNORECASE)
+
+    def __init__(self, request):
+        self.request = request
+
+    def is_user_agent_mobile(self):
+        is_mobile = False
+
+        if self.request.META.has_key('HTTP_USER_AGENT'):
+            user_agent = self.request.META['HTTP_USER_AGENT']
+
+            # Test common mobile values.
+            if self.USER_AGENTS_TEST_SEARCH_REGEX.search(user_agent) and \
+                not self.USER_AGENTS_EXCEPTION_SEARCH_REGEX.search(user_agent):
+                is_mobile = True
+            else:
+                # Nokia like test for WAP browsers.
+                # http://www.developershome.com/wap/xhtmlmp/xhtml_mp_tutorial.asp?page=mimeTypesFileExtension
+
+                if self.request.META.has_key('HTTP_ACCEPT'):
+                    http_accept = self.request.META['HTTP_ACCEPT']
+                    if self.HTTP_ACCEPT_REGEX.search(http_accept):
+                        is_mobile = True
+
+            if not is_mobile:
+                # Now we test the user_agent from a big list.
+                if self.USER_AGENTS_TEST_MATCH_REGEX.match(user_agent):
+                    is_mobile = True
+
+        return is_mobile


### PR DESCRIPTION
Hello Greg, 

First of all, thank you for taking time to make this project because it simplifies a lot things.

Let's get started.

What I propose is to add a new context processor that indicates if the request is made by a mobile user agent. Right now there is no way to know this from a template.

This makes sense in case we want to show a way to get back to mobile flavour once we have selected the full one.

Again, thank you for your time and work. Let me know what you think.

Cheers.

Javi