### PR TITLE
Allow setting flavour cookie domain and age.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -257,6 +257,21 @@ changed in your own ``settings.py``:
     
     **Default:** ``'flavour'``
 
+``FLAVOURS_COOKIE_AGE``
+    The maximum age of the flavour cookie, in seconds, or None if the cookie
+    should expire at the end of the browser session.  This is only used if
+    ``FLAVOURS_STORAGE_BACKEND`` is set to ``'cookie'``.
+    
+    **Default:** ``None``
+
+``FLAVOURS_COOKIE_DOMAIN``
+    The domain to use for the flavour cookie.  Set this to a string such as
+    ``".example.com"`` for  cross-domain cookies, or use ``None`` for a
+    standard domain cookie.  This is only used if ``FLAVOURS_STORAGE_BACKEND``
+    is set to ``'cookie'``.
+    
+    **Default:** ``None``
+
 ``FLAVOURS_TEMPLATE_PREFIX``
     This string will be prefixed to the template names when searching for
     flavoured templates. This is useful if you have many flavours and want to

--- a/django_mobile/__init__.py
+++ b/django_mobile/__init__.py
@@ -37,6 +37,8 @@ class CookieBackend(object):
             response.set_cookie(
                 smart_str(settings.FLAVOURS_COOKIE_KEY),
                 smart_str(request._flavour_cookie),
+                max_age=settings.FLAVOURS_COOKIE_AGE,
+                domain=settings.FLAVOURS_COOKIE_DOMAIN,
                 httponly=settings.FLAVOURS_COOKIE_HTTPONLY)
 
 

--- a/django_mobile/conf.py
+++ b/django_mobile/conf.py
@@ -27,6 +27,8 @@ class defaults(object):
     FLAVOURS_GET_PARAMETER = u'flavour'
     FLAVOURS_STORAGE_BACKEND = u'cookie'
     FLAVOURS_COOKIE_KEY = u'flavour'
+    FLAVOURS_COOKIE_AGE = None
+    FLAVOURS_COOKIE_DOMAIN = None
     FLAVOURS_COOKIE_HTTPONLY = False
     FLAVOURS_SESSION_KEY = u'flavour'
     FLAVOURS_TEMPLATE_LOADERS = []


### PR DESCRIPTION
This PR adds two new settings, `FLAVOURS_COOKIE_AGE` and `FLAVOURS_COOKIE_DOMAIN`, which allow the maximum age and domain for the flavour cookie to be customized if desired.
