### PR TITLE
cache_page(per-page-cache) is not working correctly.

### DIFF
--- a/django_mobile/cache/__init__.py
+++ b/django_mobile/cache/__init__.py
@@ -1,23 +1,26 @@
-from functools import wraps
 from django.views.decorators.cache import cache_page as _cache_page
 from django.utils.decorators import decorator_from_middleware
-from django_mobile.cache.middleware import CacheFlavourMiddleware
+
+from django_mobile.cache.middleware import CacheFlavourMiddleware, CacheFlavourRequestMiddleware, \
+    CacheFlavourResponseMiddleware
 
 
 __all__ = ('cache_page', 'vary_on_flavour')
 
-
 vary_on_flavour = decorator_from_middleware(CacheFlavourMiddleware)
+vary_on_flavour_request = decorator_from_middleware(CacheFlavourRequestMiddleware)
+vary_on_flavour_response = decorator_from_middleware(CacheFlavourResponseMiddleware)
 
 
 def cache_page(*args, **kwargs):
     '''
     Same as django's ``cache_page`` decorator, but wraps the view into
-    ``vary_on_flavour`` decorator before. Makes it possible to serve multiple
-    flavours without getting into trouble with django's caching that doesn't
+    ``vary_on_flavour_request`` and ``vary_on_flavour_response`` decorators.
+    Makes it possible to serve multiple flavours without getting into trouble with django's caching that doesn't
     know about flavours.
     '''
-    decorator = _cache_page(*args, **kwargs)
+
     def flavoured_decorator(func):
-        return decorator(vary_on_flavour(func))
+        return vary_on_flavour_request(_cache_page(*args, **kwargs)(vary_on_flavour_response(func)))
+
     return flavoured_decorator

--- a/django_mobile/cache/middleware.py
+++ b/django_mobile/cache/middleware.py
@@ -2,10 +2,16 @@ from django_mobile import get_flavour, _set_request_header
 from django.utils.cache import patch_vary_headers
 
 
-class CacheFlavourMiddleware(object):
+class CacheFlavourRequestMiddleware(object):
     def process_request(self, request):
         _set_request_header(request, get_flavour(request))
 
+
+class CacheFlavourResponseMiddleware(object):
     def process_response(self, request, response):
         patch_vary_headers(response, ['X-Flavour'])
         return response
+
+
+class CacheFlavourMiddleware(CacheFlavourRequestMiddleware, CacheFlavourResponseMiddleware):
+    pass


### PR DESCRIPTION
I've integrated django-mobile into my website along with Django Cache enabled but I noticed that the per-page-cache were not read and the framework sends database queries even though the pages exist in cache.

After some investigation, I found out that the issue was caused by cache_page and CacheFlavourMiddleware not taking into account the sequence of the cache process.

Expected Sequence: 
Set "HTTP_X_FLAVOUR" header -> FetchFromCacheMiddleware -> Set "Vary: X-Flavour" header -> UpdateCacheMiddleware

Current Sequence:
FetchFromCacheMiddleware -> Set "HTTP_X_FLAVOUR" header -> Set "Vary: X-Flavour" header -> UpdateCacheMiddleware

So FetchFromCacheMiddleware always looks for invalid cache.
