### PR TITLE
Add android to mobile user_agent match string

### DIFF
--- a/django_mobile/middleware.py
+++ b/django_mobile/middleware.py
@@ -37,7 +37,7 @@ class MobileDetectionMiddleware(object):
     user_agents_test_search = u"(?:%s)" % u'|'.join((
         'up.browser', 'up.link', 'mmp', 'symbian', 'smartphone', 'midp',
         'wap', 'phone', 'windows ce', 'pda', 'mobile', 'mini', 'palm',
-        'netfront', 'opera mobi',
+        'netfront', 'opera mobi', 'android',
     ))
     user_agents_exception_search = u"(?:%s)" % u'|'.join((
         'ipad',


### PR DESCRIPTION
Android devices are not getting mobile version. So add 'android' string to match string.
