### PR TITLE
Fix illegal char

### DIFF
--- a/django_mobile/__init__.py
+++ b/django_mobile/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__author__ = u'Gregor Müllegger'
+__author__ = u'Gregor Mullegger'
 __version__ = '0.4.0'
 
 


### PR DESCRIPTION
Ubuntu doesn't like the "ü".

`UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 48: ordinal not in range(128)`