### PR TITLE
[FIX] upstream cached pages showing mobile for desktop pages

### DIFF
--- a/django_mobile/middleware.py
+++ b/django_mobile/middleware.py
@@ -1,4 +1,6 @@
 import re
+from django.utils.cache import patch_vary_headers
+
 from django_mobile import flavour_storage
 from django_mobile import set_flavour, _init_flavour
 from django_mobile.conf import settings
@@ -78,3 +80,7 @@ class MobileDetectionMiddleware(object):
             set_flavour(settings.DEFAULT_MOBILE_FLAVOUR, request)
         else:
             set_flavour(settings.FLAVOURS[0], request)
+
+    def process_response(self, request, response):
+        patch_vary_headers(response, ('User-Agent',))
+        return response


### PR DESCRIPTION
We got a client complaining about mobile pages showing up for desktop browsers. Turned up that he uses a Varnish-backed server, and django-mobile serves pages based on `User-Agent` if `MobileDetectionMiddleware` is used.

It should set the `Vary: User-Agent` header.