### PR TITLE
Fix encoding issue when installing with Pip3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,10 @@ def get_author(package):
     """
     Return package version as listed in `__version__` in `init.py`.
     """
-    init_py = open(os.path.join(package, '__init__.py')).read()
+    if sys.version_info[0] >= 3 :
+        init_py = open(os.path.join(package, '__init__.py'), encoding='utf-8').read()
+    else:
+        init_py = open(os.path.join(package, '__init__.py')).read()
     author = re.search("__author__ = u?['\"]([^'\"]+)['\"]", init_py).group(1)
     return UltraMagicString(author)
 
@@ -21,7 +24,10 @@ def get_version(package):
     """
     Return package version as listed in `__version__` in `init.py`.
     """
-    init_py = open(os.path.join(package, '__init__.py')).read()
+    if sys.version_info[0] >= 3 :
+        init_py = open(os.path.join(package, '__init__.py'), encoding='utf-8').read()
+    else:
+        init_py = open(os.path.join(package, '__init__.py')).read()
     return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
 
 


### PR DESCRIPTION
When installing with pip3, the following error is given:

`UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 48: ordinal not in range(128)`

It appears that if you don't explicitly set the encoding with locale.setlocale(locale.LC_ALL, 'en_US.utf-8') --- or whatever locale, just the encoding matters AFAIK --- python will try to decode files using ascii (the `locale.getpreferredencoding(False)` function that `open()` actually depends on for the type of encoding it uses returns ANSI_X3.4-1968). This generates an issue where Python will say it cannot decode using `ascii` and the installation will fail.

I'm manually setting the encoding depending on the Python version now, i just copied line 48 (in old setup.py) to check the python version.