### PR TITLE
Fixed bug in `cache_page` decorator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -200,9 +200,8 @@ Reference
     flavours without getting into trouble with django's caching that doesn't
     know about flavours.
 
-``django_mobile.cache.vary_on_flavour_fetch``
-``django_mobile.cache.vary_on_flavour_update``
-    A decorators created from the ``FetchFromCacheFlavourMiddleware`` and ``UpdateCacheFlavourMiddleware`` middleware.
+``django_mobile.cache.vary_on_flavour_fetch`` ``django_mobile.cache.vary_on_flavour_update``
+    Decorators created from the ``FetchFromCacheFlavourMiddleware`` and ``UpdateCacheFlavourMiddleware`` middleware.
 
 ``django_mobile.cache.middleware.FetchFromCacheFlavourMiddleware``
     Adds ``X-Flavour`` header to ``request.META`` in ``process_request``

--- a/README.rst
+++ b/README.rst
@@ -152,10 +152,11 @@ You can also use django's caching middlewares
 ``django.middleware.cache.UpdateCacheMiddleware`` and
 ``FetchFromCacheMiddleware`` like you already do. But to make them aware of
 flavours, you need to add
-``django_mobile.cache.middleware.CacheFlavourMiddleware`` as second last item
-in the ``MIDDLEWARE_CLASSES`` settings, right before
-``FetchFromCacheMiddleware``.
+``django_mobile.cache.middleware.FetchFromCacheFlavourMiddleware`` item before standard Django ``FetchFromCacheMiddleware``
+in the ``MIDDLEWARE_CLASSES`` settings and ``django_mobile.cache.middleware.UpdateCacheFlavourMiddleware`` before 
+``django_mobile.cache.middleware.UpdateCacheMiddleware`` correspondingly.
 
+It is necessary to split the usage of ``CacheMiddleware`` because some additional work should be done on request and response *before* standard caching behavior and that is not possible while using two complete middlewares in either order
 
 Reference
 =========
@@ -194,16 +195,20 @@ Reference
     to ``DEFAULT_MOBILE_FLAVOUR`` settings value in case.
 
 ``django_mobile.cache.cache_page``
-    Same as django's ``cache_page`` decorator but applies ``vary_on_flavour``
-    before the view is decorated with
-    ``django.views.decorators.cache.cache_page``.
+    Same as django's ``cache_page`` decorator, but wraps the view into
+    additional decorators before and after that. Makes it possible to serve multiple
+    flavours without getting into trouble with django's caching that doesn't
+    know about flavours.
 
-``django_mobile.cache.vary_on_flavour``
-    A decorator created from the ``CacheFlavourMiddleware`` middleware.
+``django_mobile.cache.vary_on_flavour_fetch``
+``django_mobile.cache.vary_on_flavour_update``
+    A decorators created from the ``FetchFromCacheFlavourMiddleware`` and ``UpdateCacheFlavourMiddleware`` middleware.
 
-``django_mobile.cache.middleware.CacheFlavourMiddleware``
-    Adds ``X-Flavour`` header to ``request.META`` in ``process_request`` and
-    adds this header to ``response['Vary']`` in ``process_response``.
+``django_mobile.cache.middleware.FetchFromCacheFlavourMiddleware``
+    Adds ``X-Flavour`` header to ``request.META`` in ``process_request``
+
+``django_mobile.cache.middleware.UpdateCacheFlavourMiddleware``
+    Adds ``X-Flavour`` header to ``response['Vary']`` in ``process_response`` so that Django's ``CacheMiddleware`` know that it should take into account the content of this header when looking up the cached content on next request to this URL.
 
 
 Customization

--- a/django_mobile/cache/__init__.py
+++ b/django_mobile/cache/__init__.py
@@ -14,7 +14,7 @@ vary_on_flavour_update = decorator_from_middleware(UpdateCacheFlavourMiddleware)
 def cache_page(*args, **kwargs):
     '''
     Same as django's ``cache_page`` decorator, but wraps the view into
-    ``vary_on_flavour`` decorator before. Makes it possible to serve multiple
+    additional decorators before and after that. Makes it possible to serve multiple
     flavours without getting into trouble with django's caching that doesn't
     know about flavours.
     '''

--- a/django_mobile/cache/__init__.py
+++ b/django_mobile/cache/__init__.py
@@ -1,13 +1,14 @@
 from functools import wraps
-from django.views.decorators.cache import cache_page as _cache_page
+
+from django.views.decorators.cache import cache_page as _django_cache_page
 from django.utils.decorators import decorator_from_middleware
-from django_mobile.cache.middleware import CacheFlavourMiddleware
+from django_mobile.cache.middleware import FetchFromCacheFlavourMiddleware, UpdateCacheFlavourMiddleware
+
+__all__ = ('cache_page', 'vary_on_flavour_fetch', 'vary_on_flavour_update')
 
 
-__all__ = ('cache_page', 'vary_on_flavour')
-
-
-vary_on_flavour = decorator_from_middleware(CacheFlavourMiddleware)
+vary_on_flavour_fetch = decorator_from_middleware(FetchFromCacheFlavourMiddleware)
+vary_on_flavour_update = decorator_from_middleware(UpdateCacheFlavourMiddleware)
 
 
 def cache_page(*args, **kwargs):
@@ -17,7 +18,7 @@ def cache_page(*args, **kwargs):
     flavours without getting into trouble with django's caching that doesn't
     know about flavours.
     '''
-    decorator = _cache_page(*args, **kwargs)
+    decorator = _django_cache_page(*args, **kwargs)
     def flavoured_decorator(func):
-        return decorator(vary_on_flavour(func))
+        return vary_on_flavour_fetch(decorator(vary_on_flavour_update(func)))
     return flavoured_decorator

--- a/django_mobile/cache/middleware.py
+++ b/django_mobile/cache/middleware.py
@@ -1,10 +1,22 @@
-from django_mobile import get_flavour, _set_request_header
+import warnings
+
 from django.utils.cache import patch_vary_headers
+from django_mobile import get_flavour, _set_request_header
+
+
+class CacheFlavourMiddleware(object):
+    def __init__(self):
+        warnings.warn('CacheFlavourMiddleware does nothing and should be abandoned.'
+                      'The intended behavior cannot be implemented using one middleware.'
+                      'Use separate FetchFromCacheFlavourMiddleware and UpdateCacheFlavourMiddleware instead.'
+                      'Refer to https://github.com/gregmuellegger/django-mobile/pull/64 for details',
+                      category=DeprecationWarning)
 
 
 class FetchFromCacheFlavourMiddleware(object):
     def process_request(self, request):
         _set_request_header(request, get_flavour(request))
+
 
 class UpdateCacheFlavourMiddleware(object):
     def process_response(self, request, response):

--- a/django_mobile/cache/middleware.py
+++ b/django_mobile/cache/middleware.py
@@ -2,10 +2,11 @@ from django_mobile import get_flavour, _set_request_header
 from django.utils.cache import patch_vary_headers
 
 
-class CacheFlavourMiddleware(object):
+class FetchFromCacheFlavourMiddleware(object):
     def process_request(self, request):
         _set_request_header(request, get_flavour(request))
 
+class UpdateCacheFlavourMiddleware(object):
     def process_response(self, request, response):
         patch_vary_headers(response, ['X-Flavour'])
         return response


### PR DESCRIPTION
It is necessary to introduce `HTTP_X_FLAVOUR` header before standard Django `CacheMiddleware` in request
and patch `Vary:` headers before standard Django `CacheMiddleware` in response as well

Thus, nesting flavour decorator inside cache decorator is not correct and we need two separate flavour decorators for caching with flavour