### PR TITLE
Add example for tablet detection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -226,6 +226,8 @@ add your own version instead. Just make sure that it calls
 ``django_mobile.set_flavour`` at some point to set the correct flavour for
 you.
 
+If you need example how tablet detection can be implemented, you can checkout the `middleware.py`_ file in directory `examples`. Feel free to modify it as you like!
+
 Settings
 --------
 
@@ -333,6 +335,9 @@ account. To use it, put the following bit into your ``settings.py`` file:
 
 .. _cached template loader:
    https://docs.djangoproject.com/en/dev/ref/templates/api/#django.template.loaders.cached.Loader
+
+.. _middleware.py:
+   examples/middleware.py
 
 .. |build| image:: https://travis-ci.org/gregmuellegger/django-mobile.svg?branch=master
     :alt: Build Status

--- a/examples/middleware.py
+++ b/examples/middleware.py
@@ -1,0 +1,43 @@
+import re
+
+from django_mobile.middleware import MobileDetectionMiddleware
+from django_mobile import set_flavour
+from django.conf import settings
+
+
+class MobileTabletDetectionMiddleware(MobileDetectionMiddleware):
+    # Example how default middleware could be expanded to provide possibility to detect
+    # tablet devices.
+
+    user_agents_android_search = u"(?:android)"
+    user_agents_mobile_search = u"(?:mobile)"
+    user_agents_tablets_search = u"(?:%s)" % u'|'.join(('ipad', 'tablet', ))
+
+    def __init__(self):
+        super(MobileTabletDetectionMiddleware, self).__init__()
+        self.user_agents_android_search_regex = re.compile(self.user_agents_android_search,
+                                                           re.IGNORECASE)
+        self.user_agents_mobile_search_regex = re.compile(self.user_agents_mobile_search,
+                                                          re.IGNORECASE)
+        self.user_agents_tablets_search_regex = re.compile(self.user_agents_tablets_search,
+                                                           re.IGNORECASE)
+
+    def process_request(self, request):
+        is_tablet = False
+
+        user_agent = request.META.get('HTTP_USER_AGENT')
+        if user_agent:
+            # Ipad or Blackberry
+            if self.user_agents_tablets_search_regex.search(user_agent):
+                is_tablet = True
+            # Android-device. If User-Agent doesn't contain Mobile, then it's a tablet
+            elif (self.user_agents_android_search_regex.search(user_agent) and
+                  not self.user_agents_mobile_search_regex.search(user_agent)):
+                is_tablet = True
+            else:
+                # otherwise, let the superclass make decision
+                super(MobileTabletDetectionMiddleware, self).process_request(request)
+
+        # set tablet flavour. It can be `mobile`, `tablet` or anything you want
+        if is_tablet:
+            set_flavour(settings.FLAVOURS[2], request)


### PR DESCRIPTION
Hi again, Gregor!

There are some issues, complaining about tablet support (#30, #15, #16). I've decided to add the example how user can expand base `MobileDetectionMiddleware` to get `MobileTabletDetectionMiddleware`. It's just example and not supposed to be strictly solution. But it works in my case, because I mostly need to detect Android or Ipad tablets.

If you think that such feature can be included into library core, please tell, I can make another pull request, add more vendor checks and write tests on it. Thanks for your library! :iphone: :telephone_receiver: :phone: 