### PR TITLE
WIP: tackle Issue #72 (Django 1.10 Compatibility)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .tox/
+*.pyc
+*.egg-info/

--- a/django_mobile/__init__.py
+++ b/django_mobile/__init__.py
@@ -76,7 +76,6 @@ flavour_storage = ProxyBackend()
 
 
 def get_flavour(request=None, default=None):
-    import pdb; pdb.set_trace()
     flavour = None
     request = request or getattr(_local, 'request', None)
     # get flavour from storage if enabled

--- a/django_mobile/__init__.py
+++ b/django_mobile/__init__.py
@@ -76,6 +76,7 @@ flavour_storage = ProxyBackend()
 
 
 def get_flavour(request=None, default=None):
+    import pdb; pdb.set_trace()
     flavour = None
     request = request or getattr(_local, 'request', None)
     # get flavour from storage if enabled

--- a/django_mobile/conf.py
+++ b/django_mobile/conf.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.conf import settings as django_settings
+import django
 
 CACHE_LOADER_NAME = 'django_mobile.loader.CachedLoader'
 DJANGO_MOBILE_LOADER = 'django_mobile.loader.Loader'
@@ -30,7 +31,11 @@ class defaults(object):
     FLAVOURS_COOKIE_HTTPONLY = False
     FLAVOURS_SESSION_KEY = u'flavour'
     FLAVOURS_TEMPLATE_LOADERS = []
-    for loader in django_settings.TEMPLATE_LOADERS:
+    if django.VERSION[0] < 2 and django.VERSION[1] < 8 :
+        TEMPLATES = django_settings.TEMPLATE_LOADERS
+    else:
+        TEMPLATES = django_settings.TEMPLATES[0]['OPTIONS']['loaders']
+    for loader in TEMPLATES:
         if isinstance(loader, (tuple, list)) and loader[0] == CACHE_LOADER_NAME:
             for cached_loader in loader[1]:
                 if cached_loader != DJANGO_MOBILE_LOADER:

--- a/django_mobile_tests/settings.py
+++ b/django_mobile_tests/settings.py
@@ -43,13 +43,20 @@ SECRET_KEY = '0'
 ROOT_URLCONF = 'django_mobile_tests.urls'
 
 # List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-    ('django_mobile.loader.CachedLoader', (
-        'django_mobile.loader.Loader',
-        'django.template.loaders.filesystem.Loader',
-        'django.template.loaders.app_directories.Loader',
-    )),
-)
+TEMPLATES= [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'OPTIONS':{
+            'loaders':(
+                ('django_mobile.loader.CachedLoader', (
+                    'django_mobile.loader.Loader',
+                    'django.template.loaders.filesystem.Loader',
+                    'django.template.loaders.app_directories.Loader',
+                )),
+            )
+        }
+    }
+]
 
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',

--- a/django_mobile_tests/settings.py
+++ b/django_mobile_tests/settings.py
@@ -58,6 +58,8 @@ TEMPLATES= [
     }
 ]
 
+TEMPLATE_LOADERS = TEMPLATES[0]['OPTIONS']['loaders']
+
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/django_mobile_tests/test_base.py
+++ b/django_mobile_tests/test_base.py
@@ -158,7 +158,7 @@ class TemplateLoaderTests(BaseTestCase):
         result = result.strip()
         self.assertEqual(result, 'Hello .')
         # simulate RequestContext
-        result = render_to_string('index.html', context_instance=RequestContext(Mock()))
+        result = render_to_string('index.html', context = RequestContext(Mock()).flatten())
         result = result.strip()
         self.assertEqual(result, 'Hello full.')
         set_flavour('mobile')

--- a/django_mobile_tests/urls.py
+++ b/django_mobile_tests/urls.py
@@ -8,11 +8,10 @@ from django_mobile.cache import cache_page
 
 
 def index(request):
-    return render_to_response('index.html', {
-    }, context_instance=RequestContext(request))
+	return render_to_response('index.html',
+		context=RequestContext(request).flatten())
 
-
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$', index),
     url(r'^cached/$', cache_page(60*10)(index)),
-)
+]

--- a/tox.ini
+++ b/tox.ini
@@ -2,18 +2,20 @@
 minversion = 1.8
 envlist =
     py26-{15,16},
-    py27-{15,16,17,18,19,master},
+    py27-{15,16,17,18,19,110,master},
     py33-{17,18,master},
-    py34-{17,18,19,master},
-    pypy-{15,16,17,18,19,master}
+    py34-{17,18,19,110,master},
+    pypy-{15,16,17,18,19,110,master}
 
 [testenv]
 commands = python runtests.py
 deps =
+    pdbpp
     15: Django >= 1.5, < 1.6
     16: Django >= 1.6, < 1.7
     17: Django >= 1.7, < 1.8
     18: Django >= 1.8, < 1.9
     19: Django >= 1.9, < 1.10
+    110: Django >= 1.10, <1.11
     master: https://github.com/django/django/tarball/master#egg=Django
     -r{toxinidir}/requirements/tests.txt


### PR DESCRIPTION
I added a Django 1.10 support by fetching the loaders in TEMPLATES instead of TEMPLATE_LOADERS. 

I now have problems while running the tests: 
test_ipad and test_motorola_xoom are failing because for a reason I couldn't identify, the Flavour returned is None.

Any clue about the reason why it happens ? 
