### PR TITLE
Empty HTTP_USER_AGENT error in the example middleware

### DIFF
--- a/examples/middleware.py
+++ b/examples/middleware.py
@@ -41,3 +41,5 @@ class MobileTabletDetectionMiddleware(MobileDetectionMiddleware):
         # set tablet flavour. It can be `mobile`, `tablet` or anything you want
         if is_tablet:
             set_flavour(settings.FLAVOURS[2], request)
+        elif not getattr(request, 'flavour', None):
+            set_flavour(settings.FLAVOURS[0], request)


### PR DESCRIPTION
Example middleware will not set `request.flavour` when HTTP_USER_AGENT header is empty. 