### PR TITLE
django 1.10 style middleware

### DIFF
--- a/django_mobile/middleware.py
+++ b/django_mobile/middleware.py
@@ -1,10 +1,11 @@
 import re
+from django.utils.deprecation import MiddlewareMixin
 from django_mobile import flavour_storage
 from django_mobile import set_flavour, _init_flavour
 from django_mobile.conf import settings
 
 
-class SetFlavourMiddleware(object):
+class SetFlavourMiddleware(MiddlewareMixin):
     def process_request(self, request):
         _init_flavour(request)
 


### PR DESCRIPTION
makes it compatible with django 1.10 style middleware 
(ref: https://docs.djangoproject.com/en/1.11/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware).

This breaks compatibility with django 1.8 and 1.9, since `MiddlewareMixin` introduced with django 1.10